### PR TITLE
fix: use QElapsedTimer instead of QTime

### DIFF
--- a/gio-qt/source/dgiofile.cpp
+++ b/gio-qt/source/dgiofile.cpp
@@ -16,7 +16,7 @@
 #include <QDebug>
 #include <QWaitCondition>
 #include <QMutex>
-#include <QTime>
+#include <QElapsedTimer>
 #include <QtConcurrent/QtConcurrentRun>
 #include <dgiomountoperation.h>
 
@@ -224,7 +224,7 @@ QExplicitlySharedDataPointer<DGioFileInfo> DGioFile::createFileInfo(QString attr
         QSharedPointer<QMutex> m(new QMutex);
         QtConcurrent::run([&, cond, m, timeout_msec] {
             Glib::RefPtr<FileInfo> localret;
-            QTime t;
+            QElapsedTimer t;
             t.start();
             try {
                 localret = d->getGmmFileInstance()->query_info(attr.toStdString(), flags);


### PR DESCRIPTION
Fixes the following warning:
```
/build/gio-qt/src/gio-qt-0.0.12/gio-qt/source/dgiofile.cpp:228:20: warning: ‘void QTime::start()’ is deprecated: Use QElapsedTimer instead [-Wdeprecated-declarations]
  228 |             t.start();
      |             ~~~~~~~^~
```