### PR TITLE
fix: crash when calling DGioSettings::setValue

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+gio-qt (0.0.14) unstable; urgency=medium
+
+  * fix: crash when calling DGioSettings::setValue
+
+ -- ut003880 <zhangtianyi@uniontech.com>  Mon, 17 Jun 2024 21:14:25 +0800
+
 gio-qt (0.0.13) unstable; urgency=medium
 
   * add support for Qt6

--- a/gio-qt/source/dgiosettings.cpp
+++ b/gio-qt/source/dgiosettings.cpp
@@ -179,7 +179,7 @@ public:
         return false;
     }
 
-    bool inlcudeKey(const gchar* gkey) const {
+    bool includeKey(const gchar* gkey) const {
         gchar **allKeys = g_settings_list_keys(settings);
         bool ret = strvHasString (allKeys, gkey);
         g_strfreev (allKeys);
@@ -190,7 +190,7 @@ public:
     QVariant value(GSettings* gsettings, const QString& key) const {
         gchar* gkey = DGioPrivate::converToGChar(key.toUtf8());
 
-        if(!inlcudeKey(gkey)) {
+        if(!includeKey(gkey)) {
             g_free(gkey);
             return QVariant();
         }
@@ -207,7 +207,7 @@ public:
     {
         gchar* gkey = DGioPrivate::converToGChar(key.toUtf8());
 
-        if(!inlcudeKey(gkey)) {
+        if(!includeKey(gkey)) {
             g_free(gkey);
             return false;
         }

--- a/gio-qt/source/dgiosettings.cpp
+++ b/gio-qt/source/dgiosettings.cpp
@@ -205,9 +205,12 @@ public:
 
     bool trySet(const QString& key, const QVariant& value)
     {
-        const gchar* gkey = key.toUtf8().constData();
+        gchar* gkey = DGioPrivate::converToGChar(key.toUtf8());
 
-        if(!inlcudeKey(gkey)) return false;
+        if(!inlcudeKey(gkey)) {
+            g_free(gkey);
+            return false;
+        }
 
         bool success = false;
 
@@ -221,6 +224,7 @@ public:
         }
 
         g_variant_unref(cur);
+        g_free(gkey);
 
         return success;
     }


### PR DESCRIPTION
Though whether key is actually existed has been judged in DGioSettingsPrivate::trySet,
when calling g_settings_get_value, 'gkey' still seems to be empty or NULL.
Not sure what happened when converted from QString to gchar*

Log: Use DGioPrivate::convertToGChar to replace QString::toUtf8().constData()
in DGioSettingsPrivate::trySet, just like DGioSettingsPrivate::value